### PR TITLE
Adds `serde_derive` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,13 @@ categories = ["data-structures", "mathematics"]
 fpdec-core = { path = "fpdec-core", version = "0.5.0" }
 fpdec-macros = { path = "fpdec-macros", version = "0.5.0" }
 num-traits = { version = "0.2.0", optional = true }
+serde = { version = "1.0.152", optional = true, features = ["derive"] }
 
 [features]
 default = ["std"]
 std = []
 packed = []
+serde_derive = ["serde"]
 
 [workspace]
 members = [".", "fpdec-core", "fpdec-macros"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,17 +62,15 @@ extern crate alloc;
 pub use as_integer_ratio::AsIntegerRatio;
 #[doc(inline)]
 pub use binops::{
-    checked_add_sub::CheckedAdd, checked_add_sub::CheckedSub,
-    checked_div::CheckedDiv, checked_mul::CheckedMul, checked_rem::CheckedRem,
-    div_rounded::DivRounded, mul_rounded::MulRounded,
+    checked_add_sub::CheckedAdd, checked_add_sub::CheckedSub, checked_div::CheckedDiv,
+    checked_mul::CheckedMul, checked_rem::CheckedRem, div_rounded::DivRounded,
+    mul_rounded::MulRounded,
 };
 #[doc(inline)]
 pub use errors::*;
 use fpdec_core::i128_magnitude;
 #[doc(inline)]
-pub use fpdec_core::{
-    ParseDecimalError, Round, RoundingMode, MAX_N_FRAC_DIGITS,
-};
+pub use fpdec_core::{ParseDecimalError, Round, RoundingMode, MAX_N_FRAC_DIGITS};
 #[doc(inline)]
 pub use fpdec_macros::Dec;
 #[doc(inline)]
@@ -99,6 +97,7 @@ mod unops;
 #[must_use]
 #[derive(Copy, Clone)]
 #[cfg_attr(feature = "packed", repr(packed))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Decimal {
     coeff: i128,
     n_frac_digits: u8,


### PR DESCRIPTION
to allow serialization and deserialization of the `Decimal` struct.
It only takes effect if the dependency is specified as such:
```toml
fpdec = { version = "*", features = ["serde_derive"] }
```
The reason for this addition is that I would like to be able to rely on serde support in [`lfest`](https://github.com/MathisWellmann/lfest-rs) to serialize the `BaseCurrency` and `QuoteCurrency` among others.
I would love to see this change get merged and published so a new version of `lfest` can be published as well.

Thank you for such an amazing crate, I'm glad I found it!