### PR TITLE
Fix/too many fractional digits

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -30,6 +30,8 @@ where
 
 #[cfg(test)]
 mod zero_tests {
+    use fpdec_core::MAX_N_FRAC_DIGITS;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
Fix a failed test in traits.rs related to `MAX_N_FRAC_DIGITS`.