### PR TITLE
Feat/ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,4 @@ jobs:
           cargo clippy --all-features
       - name: 🎨 run cargo fmt
         run: |
-          cargo fmt --all
+          cargo fmt --all --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,6 @@ jobs:
       - name: 🔍 run cargo clippy
         run: |
           cargo clippy --all-features
+      - name: 🎨 run cargo fmt
+        run: |
+          cargo fmt --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+on: push
+
+jobs:
+  check:
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: ⬇️ checkout repository
+        uses: actions/checkout@v3
+      - name: 🛠 setup cargo toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: ♻️ cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.os }}
+      - name: ✅ run cargo check
+        run: |
+          cargo check
+          cargo check --all-features
+  test:
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ checkout repository
+        uses: actions/checkout@v3
+      - name: 🛠 setup cargo toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: ♻️ cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
+      - name: 🛟 run cargo test
+        run: |
+          cargo test
+          cargo test --all-features --doc
+  lint:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ checkout repository
+        uses: actions/checkout@v3
+      - name: 🛠 setup cargo toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: ♻️ cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
+      - name: 🔍 run cargo clippy
+        run: |
+          cargo clippy --all-features

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .*
 # except
 !.gitignore
+!.github
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html


### PR DESCRIPTION
Add CI jobs for `cargo check`, `test`, `clippy` and `fmt`.
I didn't set clippy strict mode (`-Dwarnings`) on purpose to not fail the job, but let me know if you prefer the stricter version.